### PR TITLE
Update consequence values in additionalCriteria for DoraAssessmentField

### DIFF
--- a/src/js/fields/custom/DoraAssessmentField.js
+++ b/src/js/fields/custom/DoraAssessmentField.js
@@ -180,12 +180,8 @@
                 }
                 return;
             }
-            var additionalCriteria =  [
-                { field: "DoraAssessmentClients", consequences: ["Delivery"] },
-                { field: "DoraAssessmentDataLoss", consequences: ["Information"] },
-                { field: "DoraAssessmentReputation", consequences: ["Reputation", "Relations"] },
-                { field: "DoraAssessmentDuration", consequences: ["Delivery"] },
-                { field: "DoraAssessmentGeographicalSpread", consequences: ["Delivery"] },
+            var additionalCriteria = [
+                { field: "DoraAssessmentClients", consequences: ["Customer"] },
                 { field: "DoraAssessmentEconomicImpact", consequences: ["MonetaryValues"] },
             ];
             var numAdditionalCriteria = 0;


### PR DESCRIPTION
Update DoraAssessment criteria and clean up unused fields

Changed the "consequences" for "DoraAssessmentClients" from ["Delivery"] to ["Customer"] and removed several unused criteria from the additionalCriteria array.